### PR TITLE
patch vulnerable dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4222,9 +4222,9 @@
       }
     },
     "lodash": {
-      "version": "4.17.15",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
-      "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A=="
+      "version": "4.17.19",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.19.tgz",
+      "integrity": "sha512-JNvd8XER9GQX0v2qJgsaN/mzFCNA5BRe/j8JN9d+tWyGLSodKQHKFicdwNYzWwI3wjRnaKPsGj1XkBjx/F96DQ=="
     },
     "lodash.clonedeep": {
       "version": "4.5.0",


### PR DESCRIPTION
I am not sure if this by design. I found 61 low vulnerabilities with `npm audit`. All tests passed please see below. 

```
found 61 low severity vulnerabilities in 869 scanned packages
  run `npm audit fix` to fix 61 of them.
➜  juice-shop-ctf git:(master) npm audit fix
added 869 packages from 538 contributors in 10.386s

44 packages are looking for funding
  run `npm fund` for details

fixed 61 of 61 vulnerabilities in 869 scanned packages
```

Test results

```
 72 passing (3s)

-------------------------|---------|----------|---------|---------|-------------------
File                     | % Stmts | % Branch | % Funcs | % Lines | Uncovered Line #s
-------------------------|---------|----------|---------|---------|-------------------
All files                |    99.3 |    88.57 |     100 |   99.29 |
 lib                     |     100 |       95 |     100 |     100 |
  calculateHintCost.js   |     100 |      100 |     100 |     100 |
  calculateScore.js      |     100 |      100 |     100 |     100 |
  fetchChallenges.js     |     100 |      100 |     100 |     100 |
  fetchCountryMapping.js |     100 |      100 |     100 |     100 |
  fetchSecretKey.js      |     100 |      100 |     100 |     100 |
  hmac.js                |     100 |      100 |     100 |     100 |
  options.js             |     100 |      100 |     100 |     100 |
  readConfigStream.js    |     100 |       75 |     100 |     100 | 30
  url.js                 |     100 |      100 |     100 |     100 |
  writeToCtfdZip.js      |     100 |      100 |     100 |     100 |
  writeToFbctfJson.js    |     100 |      100 |     100 |     100 |
  writeToRtbXml.js       |     100 |      100 |     100 |     100 |
 lib/generators          |   98.87 |       86 |     100 |   98.84 |
  ctfd.js                |     100 |       90 |     100 |     100 | 69
  fbctf.js               |   97.37 |     87.5 |     100 |   97.22 | 27
  rtb.js                 |   99.12 |    84.38 |     100 |    99.1 | 26
-------------------------|---------|----------|---------|---------|-------------------
```