### PR TITLE
Refactor XML element handling in RTB export and update tests for category generation

### DIFF
--- a/lib/generators/rtb.ts
+++ b/lib/generators/rtb.ts
@@ -52,7 +52,7 @@ async function createRtbExport (
   }
 
   interface FlagElement {
-    ele: (name: string, attributes?: Record<string, any>) => any
+    ele: (name: string, attributesOrText?: Record<string, any> | string | number) => any
     att: (name: string, value: string) => any
   }
 
@@ -75,7 +75,7 @@ async function createRtbExport (
   }
 
   interface BoxesElement {
-    ele: (name: string, attributes?: Record<string, any>) => any
+    ele: (name: string, attributesOrText?: Record<string, any> | string | number) => any
   }
 
   interface ChallengeWithCategory {
@@ -114,10 +114,6 @@ async function createRtbExport (
     return difficulty
   }
 
-  interface FlagElement {
-    ele: (name: string, attributes?: Record<string, any>) => any
-  }
-
   function insertFlag (
     challenge: Challenge,
     flags: FlagElement,
@@ -143,7 +139,7 @@ async function createRtbExport (
   }
 
   interface XmlElement {
-    ele: (name: string, attributes?: Record<string, any>) => XmlElement
+    ele: (name: string, attributesOrText?: Record<string, any> | string | number) => XmlElement
     up: () => XmlElement
   }
 
@@ -158,7 +154,7 @@ async function createRtbExport (
     if (categories.size > 0) {
       const categoriesXml = xmlRTB.ele('categories', { count: categories.size })
       Array.from(categories).forEach(category => {
-        categoriesXml.ele('category').ele('category', { name: category })
+        categoriesXml.ele('category').ele('category', category)
       })
       categoriesXml.up()
     }
@@ -166,16 +162,16 @@ async function createRtbExport (
   }
 
   interface XmlRTBElement {
-    ele: (name: string, attributes?: Record<string, any>) => XmlRTBElement
+    ele: (name: string, attributesOrText?: Record<string, any> | string | number) => XmlRTBElement
     up: () => XmlRTBElement
   }
 
   interface CorporationElement {
-    ele: (name: string, attributes?: Record<string, any>) => CorporationElement
+    ele: (name: string, attributesOrText?: Record<string, any> | string | number) => CorporationElement
   }
 
   interface BoxesElementReturn {
-    ele: (name: string, attributes?: Record<string, any>) => BoxesElementReturn
+    ele: (name: string, attributesOrText?: Record<string, any> | string | number) => BoxesElementReturn
   }
 
   function insertCorporation (

--- a/test/unit/generateRtbData.spec.ts
+++ b/test/unit/generateRtbData.spec.ts
@@ -61,6 +61,15 @@ describe('Generated RTB data', () => {
     assert.match(result, /<categories count="3">/)
   })
 
+  it('should generate categories with text content not attributes (RootTheBox import format)', async () => {
+    const result = await generateData(challenges, [], defaultOptions)
+    assert.ok(typeof result === 'string')
+    assert.match(result, /<category>\s*<category>1<\/category>\s*<\/category>/)
+    assert.match(result, /<category>\s*<category>2<\/category>\s*<\/category>/)
+    assert.match(result, /<category>\s*<category>3<\/category>\s*<\/category>/)
+    assert.doesNotMatch(result, /<category name="/)
+  })
+
   it('should put each given challenge as a <flag> into the matching category <box>', async () => {
     const result = await generateData(challenges, [], defaultOptions)
     assert.ok(typeof result === 'string')


### PR DESCRIPTION
### Description

Fixed RootTheBox XML export to generate categories with text content instead of attributes. The previous implementation used `<category name="value"/>` format, which is incompatible with RootTheBox's import parser. Categories now correctly generate as `<category><category>XSS</category></category>`.

**Changes:**
- Updated category XML generation in `lib/generators/rtb.ts`
- Aligned interface signatures for consistent text content support
- Removed duplicate `FlagElement` interface definition
- Added regression test to prevent future regressions

- ### Issue[#172] 
### Affirmation

- [x] My code follows the [CONTRIBUTING.md](https://github.com/juice-shop/juice-shop/blob/master/CONTRIBUTING.md) guidelines